### PR TITLE
AppImage

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -32,7 +32,6 @@ script:
   - ( cd appdir ; rm AppRun ; wget -c https://github.com/darealshinji/AppImageKit-checkrt/releases/download/continuous/AppRun-patched-x86_64 -O AppRun ; chmod a+x AppRun)
   - ./linuxdeployqt*.AppImage --appimage-extract
   - export PATH=$(readlink -f ./squashfs-root/usr/bin):$PATH
-  - NAME=$(grep '^Name=.*' appdir/usr/share/applications/audacity.desktop | cut -d "=" -f 2 | sed -e 's|\ |_|g')
   - ./squashfs-root/usr/bin/appimagetool -g ./appdir/ GitBusyLivin-$VERSION-x86_64.AppImage
 
 after_success:

--- a/.travis.yml
+++ b/.travis.yml
@@ -1,0 +1,47 @@
+language: cpp
+compiler: gcc
+sudo: require
+dist: trusty
+
+before_install:
+  - sudo add-apt-repository ppa:beineri/opt-qt-5.10.1-trusty -y
+  - sudo add-apt-repository ppa:opencpu/libgit2 -y
+  - sudo add-apt-repository ppa:ubuntu-toolchain-r/test -y
+  - sudo apt-get update -qq
+
+install:
+  - sudo apt-get -y install qt510base qt510svg gcc-8 libgit2-dev
+  - source /opt/qt*/bin/qt*-env.sh
+
+script:
+  - qmake CONFIG+=release PREFIX=/usr
+  - make -j$(nproc)
+  - # FIXME: The following 3 lines should go away, https://github.com/probonopd/linuxdeployqt#fix-for-make-nothing-to-be-done-for-install
+  - mkdir -p appdir/usr/bin ; cp GitBusyLivin appdir/usr/bin/gitbusylivin # FIXME
+  - mkdir -p appdir/usr/share/applications ; cp gitbusylivin.desktop appdir/usr/share/applications/ # FIXME
+  - mkdir -p appdir/usr/share/icons/hicolor/scalable/apps ; touch  appdir/usr/share/icons/hicolor/scalable/apps/gitbusylivin.svg # FIXME
+  - find appdir/
+  - wget -c -nv "https://github.com/probonopd/linuxdeployqt/releases/download/continuous/linuxdeployqt-continuous-x86_64.AppImage"
+  - chmod a+x linuxdeployqt-continuous-x86_64.AppImage
+  - unset QTDIR; unset QT_PLUGIN_PATH ; unset LD_LIBRARY_PATH
+  - export VERSION=$(git rev-parse --short HEAD) # linuxdeployqt uses this for naming the file
+  - ./linuxdeployqt*.AppImage ./appdir/usr/share/applications/*.desktop -bundle-non-qt-libs
+  - # Workaround to increase compatibility with older systems; see https://github.com/darealshinji/AppImageKit-checkrt for details
+  - mkdir -p appdir/usr/optional/ ; wget -c https://github.com/darealshinji/AppImageKit-checkrt/releases/download/continuous/exec-x86_64.so -O ./appdir/usr/optional/exec.so
+  - mkdir -p appdir/usr/optional/libstdc++/ ; cp /usr/lib/x86_64-linux-gnu/libstdc++.so.6 ./appdir/usr/optional/libstdc++/
+  - ( cd appdir ; rm AppRun ; wget -c https://github.com/darealshinji/AppImageKit-checkrt/releases/download/continuous/AppRun-patched-x86_64 -O AppRun ; chmod a+x AppRun)
+  - ./linuxdeployqt*.AppImage --appimage-extract
+  - export PATH=$(readlink -f ./squashfs-root/usr/bin):$PATH
+  - NAME=$(grep '^Name=.*' appdir/usr/share/applications/audacity.desktop | cut -d "=" -f 2 | sed -e 's|\ |_|g')
+  - ./squashfs-root/usr/bin/appimagetool -g ./appdir/ GitBusyLivin-$VERSION-x86_64.AppImage
+
+after_success:
+  - find appdir -executable -type f -exec ldd {} \; | grep " => /usr" | cut -d " " -f 2-3 | sort | uniq
+  - # curl --upload-file GitBusyLivin*.AppImage https://transfer.sh/GitBusyLivin-git.$(git rev-parse --short HEAD)-x86_64.AppImage
+  - wget -c https://github.com/probonopd/uploadtool/raw/master/upload.sh
+  - bash upload.sh GitBusyLivin*.AppImage*
+  
+branches:
+  except:
+    - # Do not build tags that we create when we upload to GitHub Releases
+    - /^(?i:continuous)/

--- a/gitbusylivin.desktop
+++ b/gitbusylivin.desktop
@@ -1,0 +1,10 @@
+[Desktop Entry]
+Name=GitBusyLivin
+Type=Application
+Icon=gitbusylivin
+Exec=gitbusylivin
+Comment=A Qt git client using libgit2
+Categories=Development;IDE;
+Keywords=Git;
+StartupNotify=true
+Terminal=false


### PR DESCRIPTION
![](https://user-images.githubusercontent.com/2480569/49770744-d5382a80-fcdd-11e8-9ec4-d11531290f92.png)


This PR, when merged, will compile this application on [Travis CI](https://travis-ci.org/) upon each `git push`, and upload an [AppImage](http://appimage.org/) to your GitHub Releases page.

Providing an [AppImage](http://appimage.org/) would have, among others, these advantages:
- Applications packaged as an AppImage can run on many distributions (including Ubuntu, Fedora, openSUSE, CentOS, elementaryOS, Linux Mint, and others)
- One app = one file = super simple for users: just download one AppImage file, [make it executable](http://discourse.appimage.org/t/how-to-make-an-appimage-executable/80), and run
- No unpacking or installation necessary
- No root needed
- No system libraries changed
- Works out of the box, no installation of runtimes needed
- Optional desktop integration with `appimaged`
- Optional binary delta updates, e.g., for continuous builds (only download the binary diff) using AppImageUpdate
- Can optionally GPG2-sign your AppImages (inside the file)
- Works on Live ISOs
- Can use the same AppImages when dual-booting multiple distributions
- Can be listed in the [AppImageHub](https://appimage.github.io/apps) central directory of available AppImages
- Can double as a self-extracting compressed archive with the `--appimage-extract` parameter
- No repositories needed. Suitable/optimized for air-gapped (offline) machines

[Here is an overview](https://appimage.github.io/apps) of projects that are already distributing upstream-provided, official AppImages.

__PLEASE NOTE:__ For this to work, you need to enable Travis CI for your repository as [described here](https://travis-ci.org/getting_started) __prior to merging this__, if you haven't already done so. Also, You need to set up `GITHUB_TOKEN` in Travis CI for this to work; please see https://github.com/probonopd/uploadtool.

If you have questions, AppImage developers are on #AppImage on irc.freenode.net.